### PR TITLE
Create LRU Cache Implementation using Doubly Linked List

### DIFF
--- a/LRU Cache Implementation using Doubly Linked List
+++ b/LRU Cache Implementation using Doubly Linked List
@@ -1,0 +1,100 @@
+// Java program to implement LRU Least Recently Used)
+import java.util.HashMap;
+import java.util.Map;
+
+class Node {
+    int key;
+    int value;
+    Node next;
+    Node prev;
+
+    Node(int key, int value) {
+        this.key = key;
+        this.value = value;
+        this.next = null;
+        this.prev = null;
+    }
+}
+
+class LRUCache {
+    private int capacity;
+    private Map<Integer, Node> cacheMap;
+    private Node head;
+    private Node tail;
+
+    // Constructor to initialize the cache with a given
+    // capacity
+    LRUCache(int capacity) {
+        this.capacity = capacity;
+        this.cacheMap = new HashMap<>();
+        this.head = new Node(-1, -1);
+        this.tail = new Node(-1, -1);
+        this.head.next = this.tail;
+        this.tail.prev = this.head;
+    }
+
+    // Function to get the value for a given key
+    int get(int key) {
+        if (!cacheMap.containsKey(key)) {
+            return -1;
+        }
+
+        Node node = cacheMap.get(key);
+        remove(node);
+        add(node);
+        return node.value;
+    }
+
+    // Function to put a key-value pair into the cache
+    void put(int key, int value) {
+        if (cacheMap.containsKey(key)) {
+            Node oldNode = cacheMap.get(key);
+            remove(oldNode);
+        }
+
+        Node node = new Node(key, value);
+        cacheMap.put(key, node);
+        add(node);
+
+        if (cacheMap.size() > capacity) {
+            Node nodeToDelete = tail.prev;
+            remove(nodeToDelete);
+            cacheMap.remove(nodeToDelete.key);
+        }
+    }
+
+    // Add a node right after the head (most recently used
+    // position)
+    private void add(Node node) {
+        Node nextNode = head.next;
+        head.next = node;
+        node.prev = head;
+        node.next = nextNode;
+        nextNode.prev = node;
+    }
+
+    // Remove a node from the list
+    private void remove(Node node) {
+        Node prevNode = node.prev;
+        Node nextNode = node.next;
+        prevNode.next = nextNode;
+        nextNode.prev = prevNode;
+    }
+}
+
+
+public class Main {
+    public static void main(String[] args) {
+        LRUCache cache = new LRUCache(2);
+
+        cache.put(1, 1);
+        cache.put(2, 2);
+        System.out.println(cache.get(1));
+        cache.put(3, 3);
+        System.out.println(cache.get(2));
+        cache.put(4, 4);
+        System.out.println(cache.get(1));
+        System.out.println(cache.get(3));
+        System.out.println(cache.get(4));
+    }
+}


### PR DESCRIPTION
The idea is to keep inserting the key-value pair at the head of the doubly linked list. When a node is accessed or added, it is moved to the head of the list (right after the dummy head node). This marks it as the most recently used. When the cache exceeds its capacity, the node at the tail (right before the dummy tail node) is removed as it represents the least recently used item.

Doubly-Linked-List-Representation-Of-LRU-Cache-5.webp