### PR TITLE
Create Largest Rectangular Area in a Histogram

### DIFF
--- a/Largest Rectangular Area in a Histogram
+++ b/Largest Rectangular Area in a Histogram
@@ -1,0 +1,52 @@
+// Java program to find the largest rectangular area possible 
+// in a given histogram 
+
+import java.util.Stack;
+
+class GfG {
+    
+    // Function to calculate the maximum rectangular area
+    static int getMaxArea(int[] arr) {
+        int n = arr.length;
+        Stack<Integer> s = new Stack<>();
+        int res = 0, tp, curr;
+        
+        for (int i = 0; i < n; i++) {  
+          
+            // Process the stack while the current element 
+            // is smaller than the element corresponding to 
+            // the top of the stack
+            while (!s.isEmpty() && arr[s.peek()] >= arr[i]) {
+              
+                // The popped item is to be considered as the 
+                // smallest element of the Histogram
+                tp = s.pop();
+                
+                // For the popped item, previous smaller element
+                // is just below it in the stack (or current stack 
+                // top) and next smaller element is i
+                int width = s.isEmpty() ? i : i - s.peek() - 1;
+                
+                // Update the result if needed
+                res = Math.max(res, arr[tp] * width);
+            }
+            s.push(i);
+        }
+
+        // For the remaining items in the stack, next smaller does
+        // not exist. Previous smaller is the item just below in
+        // the stack.
+        while (!s.isEmpty()) {
+            tp = s.pop();
+            curr = arr[tp] * (s.isEmpty() ? n : n - s.peek() - 1);
+            res = Math.max(res, curr);
+        }
+
+        return res;
+    }
+
+    public static void main(String[] args) {
+        int[] arr = {60, 20, 50, 40, 10, 50, 60};
+        System.out.println(getMaxArea(arr));
+    }
+}


### PR DESCRIPTION
his approach is mainly an optimization over the previous approach.

When we compute next smaller element, we pop an item from the stack and mark current item as next smaller of it. One important observation here is the item below every item in stack is the previous smaller element. So we do not need to explicitly compute previous smaller. 

Below are the detailed steps of implementation.

Create an empty stack.

Start from the first bar, and do the following for every bar arr[i] where 'i' varies from 0 to n-1

If the stack is empty or arr[i] is higher than the bar at top of the stack, then push 'i' to stack.  If this bar is smaller than the top of the stack, then keep removing the top of the stack while the top of the stack is greater. 

Let the removed bar be arr[tp]. Calculate the area of the rectangle with arr[tp] as the smallest bar. 

For arr[tp], the 'left index' is previous (previous to tp) item in stack and 'right index' is 'i' (current index).

If the stack is not empty, then one by one remove all bars from the stack and do step (2.2 and 2.3) for every removed bar Largest-Rectangular-Area-in-a-Histogram-6.webp